### PR TITLE
Set the correct JDK compliance level for development

### DIFF
--- a/mkdocs/docs/doc/articles/running-from-source/index.md
+++ b/mkdocs/docs/doc/articles/running-from-source/index.md
@@ -7,6 +7,7 @@ To run Epsilon from source, you need to:
 - Import all the projects under the `plugins`, `features`, and `tests` folders in your workspace.
 - (optional) To organise your workspace, you can create [working sets](http://help.eclipse.org/kepler/index.jsp?topic=%2Forg.eclipse.platform.doc.user%2Fconcepts%2Fcworkset.htm). For example, you could create three working sets that mirror the contents of the folders above (`plugins`, `features`, and `tests`).
 - Open `releng/org.eclipse.epsilon.target/org.eclipse.epsilon.target.target` and click the "Set as Active Target Platform" link on the top right
+- Make sure that your Java compiler is set in compliance mode 1.8. This can be set in window/preferences/Java/Compiler
 - Right-click on any Epsilon plugin project in the Project Explorer and select Run as → Eclipse Application
 
 !!! warning "Using your own Eclipse IDE and Maven m2e integration"


### PR DESCRIPTION
Small improvement to the instructions for new epsilon contributors