### PR TITLE
Adding support for EMG with an example

### DIFF
--- a/mkdocs/docs/playground/css/custom.css
+++ b/mkdocs/docs/playground/css/custom.css
@@ -72,6 +72,10 @@
     content: url("../images/etl.png");
 }
 
+.mif-emg::before {
+    content: url("../images/epl.gif");
+}
+
 .mif-epl::before {
     content: url("../images/epl.png");
 }

--- a/mkdocs/docs/playground/cypress/e2e/download.cy.js
+++ b/mkdocs/docs/playground/cypress/e2e/download.cy.js
@@ -23,7 +23,7 @@ const environments = [
         success: "BUILD SUCCESS"
     }
 ]
-const examples = ["eol", "etl", "evl", "epl", "egl", "egx", "flock", "eml"];
+const examples = ["eol", "etl", "emg", "evl", "epl", "egl", "egx", "flock", "eml"];
 
 // This test can be a bit flaky and fail for no particular reason for some examples
 // Before attempting to fix anything, try to run it a few times or against the failing example or environment

--- a/mkdocs/docs/playground/cypress/e2e/emg.cy.js
+++ b/mkdocs/docs/playground/cypress/e2e/emg.cy.js
@@ -6,10 +6,9 @@ describe('Tests the default EMG example', () => {
     }),
     it('Tests that the example loads fine and there is text in all editors', () => {
       cy.contains('PetriNet create()');
-      cy.contains('?nsuri PetriNet');
-      cy.contains('package PetriNet;');
+      cy.contains('package petriNet;');
     }),
-    it('Checks that the transformation runs fine and a deliverable is produced', () => {
+    it('Checks that the generation runs fine and a Petri Net is produced', () => {
       cy.get(runButton).click();
       cy.contains(":PetriNet");
     })

--- a/mkdocs/docs/playground/cypress/e2e/emg.cy.js
+++ b/mkdocs/docs/playground/cypress/e2e/emg.cy.js
@@ -1,0 +1,16 @@
+import { playground, runButton } from './constants.js';
+
+describe('Tests the default EMG example', () => {
+    beforeEach(() => {
+      cy.visit(playground + "?emg");
+    }),
+    it('Tests that the example loads fine and there is text in all editors', () => {
+      cy.contains('PetriNet create()');
+      cy.contains('?nsuri PetriNet');
+      cy.contains('package PetriNet;');
+    }),
+    it('Checks that the transformation runs fine and a deliverable is produced', () => {
+      cy.get(runButton).click();
+      cy.contains(":PetriNet");
+    })
+  });

--- a/mkdocs/docs/playground/examples/examples.json
+++ b/mkdocs/docs/playground/examples/examples.json
@@ -345,5 +345,18 @@
 				"emfatic": "tree.emf",
 				"secondEmfatic": "graph.emf"
 			}
-	]}
+	]},
+	{
+		"title": "Model Generation Examples",
+		"examples": [
+			{
+				"id": "emg",
+				"title": "Petri Net Generation",
+				"language": "emg",
+				"program": "petri-net/petri.emg",
+				"flexmi": "petri-net/petri.flexmi",
+				"emfatic": "petri-net/petri.emf"
+			}
+		]
+	}
 ]}

--- a/mkdocs/docs/playground/examples/examples.json
+++ b/mkdocs/docs/playground/examples/examples.json
@@ -354,7 +354,6 @@
 				"title": "Petri Net Generation",
 				"language": "emg",
 				"program": "petri-net/petri.emg",
-				"flexmi": "petri-net/petri.flexmi",
 				"emfatic": "petri-net/petri.emf"
 			}
 		]

--- a/mkdocs/docs/playground/examples/petri-net/petri.emf
+++ b/mkdocs/docs/playground/examples/petri-net/petri.emf
@@ -1,4 +1,4 @@
-package PetriNet;
+package petriNet;
 
 abstract class Element {
   attr String name;

--- a/mkdocs/docs/playground/examples/petri-net/petri.emf
+++ b/mkdocs/docs/playground/examples/petri-net/petri.emf
@@ -1,0 +1,39 @@
+package PetriNet;
+
+abstract class Element {
+  !ordered attr String[1] name;
+}
+
+class PetriNet extends Element {
+  val Place[+] places;
+  val Transition[*] transitions;
+  val Arc[*] arcs;
+}
+
+class Place extends Element {
+  !ordered ref TransToPlaceArc[*]#target incoming;
+  !ordered ref PlaceToTransArc[*]#source outgoing;
+}
+
+class Transition extends Element {
+  !ordered ref PlaceToTransArc[+]#target incoming;
+  !ordered ref TransToPlaceArc[+]#source outgoing;
+}
+
+class Arc {
+  !ordered attr int[1] weight;
+}
+
+class PlaceToTransArc extends Arc {
+  @diagram(direction="none")
+  !ordered ref Place[1]#outgoing source;
+  @diagram(direction="none")
+  !ordered ref Transition[1]#incoming target;
+}
+
+class TransToPlaceArc extends Arc {
+  @diagram(direction="none")
+  !ordered ref Transition[1]#outgoing source;
+  @diagram(direction="none")
+  !ordered ref Place[1]#incoming target;
+}

--- a/mkdocs/docs/playground/examples/petri-net/petri.emf
+++ b/mkdocs/docs/playground/examples/petri-net/petri.emf
@@ -1,7 +1,7 @@
 package PetriNet;
 
 abstract class Element {
-  !ordered attr String[1] name;
+  attr String name;
 }
 
 class PetriNet extends Element {
@@ -11,29 +11,29 @@ class PetriNet extends Element {
 }
 
 class Place extends Element {
-  !ordered ref TransToPlaceArc[*]#target incoming;
-  !ordered ref PlaceToTransArc[*]#source outgoing;
+  ref TransToPlaceArc[*]#target incoming;
+  ref PlaceToTransArc[*]#source outgoing;
 }
 
 class Transition extends Element {
-  !ordered ref PlaceToTransArc[+]#target incoming;
-  !ordered ref TransToPlaceArc[+]#source outgoing;
+  ref PlaceToTransArc[+]#target incoming;
+  ref TransToPlaceArc[+]#source outgoing;
 }
 
 class Arc {
-  !ordered attr int[1] weight;
+  attr int weight;
 }
 
 class PlaceToTransArc extends Arc {
   @diagram(direction="none")
-  !ordered ref Place[1]#outgoing source;
+  ref Place#outgoing source;
   @diagram(direction="none")
-  !ordered ref Transition[1]#incoming target;
+  ref Transition#incoming target;
 }
 
 class TransToPlaceArc extends Arc {
   @diagram(direction="none")
-  !ordered ref Transition[1]#outgoing source;
+  ref Transition#outgoing source;
   @diagram(direction="none")
-  !ordered ref Place[1]#incoming target;
+  ref Place#incoming target;
 }

--- a/mkdocs/docs/playground/examples/petri-net/petri.emg
+++ b/mkdocs/docs/playground/examples/petri-net/petri.emg
@@ -1,0 +1,56 @@
+pre {
+    var num_p = 3;
+}
+
+$instances 1
+@list net
+operation PetriNet create() {
+    self.name = nextCamelCaseString(15, 10);
+}
+
+$instances num_p
+operation Place create() {
+    self.name = "P_" + nextString("LETTER_LOWER", 15);
+    nextFromList("net").transitions.add(self);
+}
+
+$instances num_p / 2
+operation Transition create() {
+    self.name = "T_" + nextString("LETTER_LOWER", 15);
+    nextFromList("net").transitions.add(self);
+}
+
+@probability 0.7
+pattern Transition
+net:PetriNet,
+tra:Transition
+from: net.transitions {
+    onmatch {
+        var size = 0;
+        var freeSources = Place.all().select(s | s.incoming.size() == size);
+        while (freeSources.isEmpty()) {
+            size += 1;
+            freeSources = Place.all().select(s | s.incoming.size() == size);
+        }
+        size = 0;
+        var freeTarget = Place.all().select(s | s.outgoing.size() == size);
+        while (freeTarget.isEmpty()) {
+            size += 1;
+            freeTarget = Place.all().select(s | s.outgoing.size() == size);
+        }
+        var source = nextFromCollection(freeSources);
+        var target = nextFromCollection(freeTarget);
+        var a1:Arc = new PlaceToTransArc();
+        a1.weight = nextInt(10);
+        a1.source = source;
+        net.places.add(source);
+        a1.target = tra;
+        net.arcs.add(a1);
+        var a2:Arc = new TransToPlaceArc();
+        a1.weight = nextInt(10);
+        a2.source = tra;
+        a2.target = target;
+        net.places.add(target);
+        net.arcs.add(a2);
+    }
+}

--- a/mkdocs/docs/playground/examples/petri-net/petri.flexmi
+++ b/mkdocs/docs/playground/examples/petri-net/petri.flexmi
@@ -1,3 +1,0 @@
-<?nsuri PetriNet?>
-<_>
-</_>

--- a/mkdocs/docs/playground/examples/petri-net/petri.flexmi
+++ b/mkdocs/docs/playground/examples/petri-net/petri.flexmi
@@ -1,0 +1,3 @@
+<?nsuri PetriNet?>
+<_>
+</_>

--- a/mkdocs/docs/playground/js/DownloadDialog.js
+++ b/mkdocs/docs/playground/js/DownloadDialog.js
@@ -50,6 +50,8 @@ class DownloadDialog {
                             zip.file("right.flexmi", thirdModelPanel.getValue());
                             zip.file("right.emf", thirdMetamodelPanel.getValue());
                             zip.file("target.emf", secondMetamodelPanel.getValue());                            
+                        } else if (language == "emg") {
+                            zip.file("metamodel.emf", firstMetamodelPanel.getValue());
                         }
                         else {
                             zip.file("model.flexmi", firstModelPanel.getValue());

--- a/mkdocs/docs/playground/js/DownloadDialog.js
+++ b/mkdocs/docs/playground/js/DownloadDialog.js
@@ -24,6 +24,7 @@ class DownloadDialog {
                             task: language == "egx" ? "egl" : language,
                             extension: extension,
                             etl: language == "etl",
+                            emg: language == "emg",
                             flock: language == "flock",
                             etlOrFlock: language == "etl" || language == "flock",
                             egl: language == "egl",
@@ -38,7 +39,7 @@ class DownloadDialog {
                         if (language == "egx") zip.file("template.egl", secondProgramPanel.getEditor().getValue());
                         if (language == "eml") zip.file("program.ecl", secondProgramPanel.getEditor().getValue());
 
-                        if (language == "etl" || language == "flock") {
+                        if (language == "etl" || language == "emg" || language == "flock") {
                             zip.file(templateData.sourceModelFileName + ".flexmi", firstModelPanel.getValue());
                             zip.file(templateData.sourceModelFileName + ".emf", firstMetamodelPanel.getValue());
                             zip.file(templateData.targetModelFileName + ".emf", secondMetamodelPanel.getValue());

--- a/mkdocs/docs/playground/js/DownloadDialog.js
+++ b/mkdocs/docs/playground/js/DownloadDialog.js
@@ -39,7 +39,7 @@ class DownloadDialog {
                         if (language == "egx") zip.file("template.egl", secondProgramPanel.getEditor().getValue());
                         if (language == "eml") zip.file("program.ecl", secondProgramPanel.getEditor().getValue());
 
-                        if (language == "etl" || language == "emg" || language == "flock") {
+                        if (language == "etl" || language == "flock") {
                             zip.file(templateData.sourceModelFileName + ".flexmi", firstModelPanel.getValue());
                             zip.file(templateData.sourceModelFileName + ".emf", firstMetamodelPanel.getValue());
                             zip.file(templateData.targetModelFileName + ".emf", secondMetamodelPanel.getValue());

--- a/mkdocs/docs/playground/js/Layout.js
+++ b/mkdocs/docs/playground/js/Layout.js
@@ -42,7 +42,7 @@ class Layout {
             splitter = new Splitter(
                 new Splitter(programPanel, consolePanel, "vertical"),
                 new Splitter(
-                    new Splitter(firstModelPanel, firstMetamodelPanel, "vertical"),
+                    new Splitter(firstMetamodelPanel, null, "vertical"),
                     new Splitter(secondModelPanel, null)
                 ), 
                 "horizontal", "33, 67"

--- a/mkdocs/docs/playground/js/Layout.js
+++ b/mkdocs/docs/playground/js/Layout.js
@@ -37,6 +37,17 @@ class Layout {
                 "horizontal", "33, 67"
             );
         }
+        else if (language == "emg") {
+
+            splitter = new Splitter(
+                new Splitter(programPanel, consolePanel, "vertical"),
+                new Splitter(
+                    new Splitter(firstModelPanel, firstMetamodelPanel, "vertical"),
+                    new Splitter(secondModelPanel, null)
+                ), 
+                "horizontal", "33, 67"
+            );
+        }
         else if (language == "egx") {
 
             splitter = new Splitter(

--- a/mkdocs/docs/playground/js/Playground.js
+++ b/mkdocs/docs/playground/js/Playground.js
@@ -58,7 +58,7 @@ function setup() {
     if (example.outputType != null) {outputType = example.outputType;}
     if (example.outputLanguage != null) {outputLanguage = example.outputLanguage;}
     
-    var secondModelEditable = !(language == "etl" || language == "flock" || language == "eml");
+    var secondModelEditable = !(language == "etl" || language == "emg" || language == "flock" || language == "eml");
 
     secondModelPanel = new ModelPanel("secondModel", secondModelEditable, secondMetamodelPanel);
     outputPanel = new OutputPanel("output", language, outputType, outputLanguage);
@@ -178,7 +178,7 @@ function arrangePanels() {
             outputPanel.setTitleAndIcon("Generated Text", "editor");           
         }
     }
-    else if (language == "etl") {
+    else if (language == "etl" || language == "emg") {
         secondModelPanel.showDiagram();
         secondModelPanel.hideEditor();
 
@@ -272,7 +272,7 @@ function runProgram() {
                 else {
                     consolePanel.setOutput(response.output);
                     
-                    if (language == "etl" || language == "flock" || language == "eml") {
+                    if (language == "etl" || language == "emg" || language == "flock" || language == "eml") {
                         secondModelPanel.renderDiagram(response.targetModelDiagram);
                     }
                     else if (language == "evl") {
@@ -341,7 +341,7 @@ function runProgram() {
 function getActivePanels() {
     var panels = [programPanel, consolePanel, firstModelPanel, firstMetamodelPanel];
 
-    if (language == "etl" || language == "flock") {
+    if (language == "etl" || language == "emg" || language == "flock") {
         panels.push(secondModelPanel, secondMetamodelPanel);
     }
     else if (language == "eml") {

--- a/mkdocs/docs/playground/js/ProgramPanel.js
+++ b/mkdocs/docs/playground/js/ProgramPanel.js
@@ -17,6 +17,7 @@ class ProgramPanel extends Panel {
         switch (language) {
             case "eol": title = "Program"; break;
             case "etl": title = "Transformation"; break;
+            case "emg": title = "Generation"; break;
             case "flock": title = "Migration"; break;
             case "egl": title = "Template"; break;
             case "evl": title = "Constraints"; break;

--- a/mkdocs/docs/playground/js/SettingsDialog.js
+++ b/mkdocs/docs/playground/js/SettingsDialog.js
@@ -9,7 +9,7 @@ class SettingsDialog {
 
         var panels = [programPanel, consolePanel, firstModelPanel, firstMetamodelPanel];
 
-        if (language == "etl" || language == "flock") {
+        if (language == "etl" || language == "emg" || language == "flock") {
             panels.push(secondModelPanel, secondMetamodelPanel);
         }
         else if (language == "eml") {

--- a/mkdocs/docs/playground/js/highlighting/emg.js
+++ b/mkdocs/docs/playground/js/highlighting/emg.js
@@ -1,0 +1,93 @@
+import {define} from "ace-builds";
+
+define("ace/mode/emg_highlight_rules",["require","exports","module","ace/lib/oop","ace/mode/text_highlight_rules"], function(require, exports, module) {
+"use strict";
+
+var oop = require("../lib/oop");
+var TextHighlightRules = require("./text_highlight_rules").TextHighlightRules;
+
+var emgHighlightRules = function() {
+
+    var keywords = (
+        "match|onmatch|nomatch|pattern|do|from|pre|post|not|delete|import|for|while|in|and|or|operation|return|var|throw|if|new|else|transaction|abort|break|continue|assert|assertError|not|function|default|switch|case|as|ext|driver|alias|model|breakAll|async|group|nor|xor|implies|$instances"
+    );
+
+    var builtinConstants = (
+        "true|false|self"
+    );
+
+    var builtinFunctions = (
+        ""
+    );
+
+    var dataTypes = (
+        "Any|String|Integer|Real|Boolean|Native|Bag|Set|List|Sequence|Map|OrderedSet|Collection|Tuple|ConcurrentBag|ConcurrentMap|ConcurrentSet"
+    );
+
+    var keywordMapper = this.createKeywordMapper({
+        "support.function": builtinFunctions,
+        "keyword": keywords,
+        "constant.language": builtinConstants,
+        "storage.type": dataTypes
+    }, "identifier", false);
+
+    this.$rules = {
+        "start" : [ {
+            token : "comment",
+            regex : "//.*$"
+        },  {
+            token : "comment",
+            start : "/\\*",
+            end : "\\*/"
+        }, {
+            token : "string",           // " string
+            regex : '".*?"'
+        }, {
+            token : "string",           // ' string
+            regex : "'.*?'"
+        }, {
+            token : "string",           // ` string (apache drill)
+            regex : "`.*?`"
+        }, {
+            token : "constant.numeric", // float
+            regex : "[+-]?\\d+(?:(?:\\.\\d*)?(?:[eE][+-]?\\d+)?)?\\b"
+        }, {
+            token: "keyword",
+            regex: "(@list|@probability)"
+        }, {
+            token : keywordMapper,
+            regex : "[a-zA-Z_$][a-zA-Z0-9_$]*\\b"
+        }, {
+            token : "text",
+            regex : "\\s+"
+        }]
+    };
+    this.normalizeRules();
+};
+
+oop.inherits(emgHighlightRules, TextHighlightRules);
+
+exports.emgHighlightRules = emgHighlightRules;
+});
+
+define("ace/mode/emg",["require","exports","module","ace/lib/oop","ace/mode/text","ace/mode/emg_highlight_rules"], function(require, exports, module) {
+"use strict";
+
+var oop = require("../lib/oop");
+var TextMode = require("./text").Mode;
+var emgHighlightRules = require("./emg_highlight_rules").emgHighlightRules;
+
+var Mode = function() {
+    this.HighlightRules = emgHighlightRules;
+    this.$behaviour = this.$defaultBehaviour;
+};
+oop.inherits(Mode, TextMode);
+
+(function() {
+    this.$id = "ace/mode/emg";
+    this.snippetFileId = "ace/snippets/emg";
+}).call(Mode.prototype);
+
+exports.Mode = Mode;
+
+});

--- a/mkdocs/docs/playground/js/highlighting/highlighting.js
+++ b/mkdocs/docs/playground/js/highlighting/highlighting.js
@@ -1,5 +1,6 @@
 import './eol.js';
 import './etl.js';
+import './emg.js';
 import './flock.js';
 import './evl.js';
 import './epl.js';

--- a/mkdocs/docs/playground/templates/ant/ant.xml.handlebars
+++ b/mkdocs/docs/playground/templates/ant/ant.xml.handlebars
@@ -41,6 +41,14 @@
 <!-- Dispose of both models -->
 <epsilon.disposeModel model="{{ sourceModelName }}"/>
 <epsilon.disposeModel model="{{ targetModelName }}"/>
+{{else if emg}}
+<!-- Generate the model in model.xmi using metamodel.emf as the metamodel -->
+<epsilon.emf.loadModel name="Model" modelfile="model.xmi" metamodelfile="metamodel.emf" read="false" store="true"/>
+<!-- Run program.emg against it  -->
+<epsilon.emg src="program.emg">
+    <model ref="Model"/>
+</epsilon.emg>
+<epsilon.disposeModel model="Model"/>
 {{else}}
 <!-- Load the model.flexmi EMF model -->
 <epsilon.emf.loadModel name="M" modelfile="model.flexmi" metamodelfile="metamodel.emf" />

--- a/mkdocs/docs/playground/templates/gradle/build.gradle.handlebars
+++ b/mkdocs/docs/playground/templates/gradle/build.gradle.handlebars
@@ -10,7 +10,7 @@ repositories {
 }
 
 dependencies {
-    epsilon 'org.eclipse.epsilon:org.eclipse.epsilon.workflow:2.4.0'
+    epsilon 'org.eclipse.epsilon:org.eclipse.epsilon.workflow:2.5.0-SNAPSHOT'
     epsilon 'org.eclipse.epsilon:org.eclipse.epsilon.workflow.emf:2.4.0'
     epsilon ('org.eclipse.emfatic:org.eclipse.emfatic.core:1.1.0-SNAPSHOT') {
         exclude group: 'org.eclipse.platform'

--- a/mkdocs/docs/playground/templates/gradle/build.gradle.handlebars
+++ b/mkdocs/docs/playground/templates/gradle/build.gradle.handlebars
@@ -10,7 +10,7 @@ repositories {
 }
 
 dependencies {
-    epsilon 'org.eclipse.epsilon:org.eclipse.epsilon.workflow:2.5.0-SNAPSHOT'
+    epsilon 'org.eclipse.epsilon:org.eclipse.epsilon.workflow:2.5.0'
     epsilon 'org.eclipse.epsilon:org.eclipse.epsilon.workflow.emf:2.4.0'
     epsilon ('org.eclipse.emfatic:org.eclipse.emfatic.core:1.1.0-SNAPSHOT') {
         exclude group: 'org.eclipse.platform'

--- a/mkdocs/docs/playground/templates/gradle/build.gradle.handlebars
+++ b/mkdocs/docs/playground/templates/gradle/build.gradle.handlebars
@@ -60,6 +60,12 @@ task run {
 
     // Run program.{{ extension }} against them
     ant.'epsilon.{{ task }}'(src: 'program.{{ extension }}'{{#if flock}}, originalModel: '{{ sourceModelName }}', migratedModel: '{{ targetModelName }}'{{/if}}){[ model(ref: '{{ sourceModelName }}'), model(ref: '{{ targetModelName }}') ]}
+    {{else if emg}}
+    // Generate the model in model.xmi using metamodel.emf as the metamodel
+    ant.'epsilon.emf.loadModel'(name: 'Model', modelfile: 'model.xmi', metamodelfile: 'metamodel.emf', read: false, store: true)
+
+    // Run program.emg against it
+    ant.'epsilon.emg'(src: 'program.emg'){ model(ref: 'Model') }
     {{else}}
     // Load the model.flexmi EMF model
     ant.'epsilon.emf.loadModel'(name: 'M', modelfile: 'model.flexmi', metamodelfile: 'metamodel.emf')

--- a/mkdocs/docs/playground/templates/java/emg/build.gradle
+++ b/mkdocs/docs/playground/templates/java/emg/build.gradle
@@ -1,0 +1,23 @@
+plugins {
+    id 'application'
+}
+
+application {
+    mainClass = 'org.eclipse.epsilon.examples.Example'
+}
+
+repositories {
+    mavenCentral()
+    maven {
+        url "https://oss.sonatype.org/content/repositories/snapshots"
+    }
+}
+
+dependencies {
+    implementation("org.eclipse.epsilon:org.eclipse.epsilon.emg.engine:2.4.0");
+    implementation("org.eclipse.epsilon:org.eclipse.epsilon.emc.emf:2.4.0");
+    implementation("org.eclipse.epsilon:org.eclipse.epsilon.flexmi:2.4.0");
+    implementation("org.eclipse.emfatic:org.eclipse.emfatic.core:1.1.0-SNAPSHOT") {
+        exclude group: 'org.eclipse.platform'
+    }
+}

--- a/mkdocs/docs/playground/templates/java/emg/metamodel.emf
+++ b/mkdocs/docs/playground/templates/java/emg/metamodel.emf
@@ -1,0 +1,39 @@
+package petriNet;
+
+abstract class Element {
+  attr String name;
+}
+
+class PetriNet extends Element {
+  val Place[+] places;
+  val Transition[*] transitions;
+  val Arc[*] arcs;
+}
+
+class Place extends Element {
+  ref TransToPlaceArc[*]#target incoming;
+  ref PlaceToTransArc[*]#source outgoing;
+}
+
+class Transition extends Element {
+  ref PlaceToTransArc[+]#target incoming;
+  ref TransToPlaceArc[+]#source outgoing;
+}
+
+class Arc {
+  attr int weight;
+}
+
+class PlaceToTransArc extends Arc {
+  @diagram(direction="none")
+  ref Place#outgoing source;
+  @diagram(direction="none")
+  ref Transition#incoming target;
+}
+
+class TransToPlaceArc extends Arc {
+  @diagram(direction="none")
+  ref Transition#outgoing source;
+  @diagram(direction="none")
+  ref Place#incoming target;
+}

--- a/mkdocs/docs/playground/templates/java/emg/pom.xml
+++ b/mkdocs/docs/playground/templates/java/emg/pom.xml
@@ -1,0 +1,83 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd"
+	xmlns="http://maven.apache.org/POM/4.0.0"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+	<modelVersion>4.0.0</modelVersion>
+
+	<groupId>org.eclipse.epsilon</groupId>
+	<artifactId>examples</artifactId>
+	<version>1.0.0-SNAPSHOT</version>
+
+	<repositories>
+		<repository>
+			<id>ossrh</id>
+			<url>https://oss.sonatype.org/content/repositories/snapshots</url>
+			<releases>
+				<enabled>false</enabled>
+			</releases>
+			<snapshots>
+				<enabled>true</enabled>
+			</snapshots>
+		</repository>
+	</repositories>
+
+	<properties>
+		<epsilon.version>2.4.0</epsilon.version>
+		<epsilon.scope>compile</epsilon.scope>
+		<maven.compiler.source>11</maven.compiler.source>
+		<maven.compiler.target>11</maven.compiler.target>
+	</properties>
+
+	<build>
+		<plugins>
+			<plugin>
+				<groupId>org.codehaus.mojo</groupId>
+				<artifactId>exec-maven-plugin</artifactId>
+				<version>3.1.0</version>
+				<configuration>
+					<mainClass>org.eclipse.epsilon.examples.Example</mainClass>
+					<systemProperties>
+						<systemProperty>
+							<key>org.eclipse.emf.common.util.ReferenceClearingQueue</key>
+							<value>false</value>
+						</systemProperty>
+					</systemProperties>
+				</configuration>
+			</plugin>
+		</plugins>
+	</build>
+	
+	<dependencies>
+		<dependency>
+			<groupId>org.eclipse.epsilon</groupId>
+			<artifactId>org.eclipse.epsilon.emc.emf</artifactId>
+			<version>${epsilon.version}</version>
+			<scope>${epsilon.scope}</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.eclipse.epsilon</groupId>
+			<artifactId>org.eclipse.epsilon.emg.engine</artifactId>
+			<version>${epsilon.version}</version>
+			<scope>${epsilon.scope}</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.eclipse.epsilon</groupId>
+			<artifactId>org.eclipse.epsilon.flexmi</artifactId>
+			<version>${epsilon.version}</version>
+			<scope>${epsilon.scope}</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.eclipse.emfatic</groupId>
+			<artifactId>org.eclipse.emfatic.core</artifactId>
+			<version>1.1.0-SNAPSHOT</version>
+			<exclusions>
+				<exclusion>
+					<groupId>org.eclipse.platform</groupId>
+					<artifactId>*</artifactId>
+				</exclusion>
+			</exclusions>
+		</dependency>
+	</dependencies>
+
+</project>

--- a/mkdocs/docs/playground/templates/java/emg/program.emg
+++ b/mkdocs/docs/playground/templates/java/emg/program.emg
@@ -1,0 +1,56 @@
+pre {
+    var num_p = 3;
+}
+
+$instances 1
+@list net
+operation PetriNet create() {
+    self.name = nextCamelCaseString(15, 10);
+}
+
+$instances num_p
+operation Place create() {
+    self.name = "P_" + nextString("LETTER_LOWER", 15);
+    nextFromList("net").transitions.add(self);
+}
+
+$instances num_p / 2
+operation Transition create() {
+    self.name = "T_" + nextString("LETTER_LOWER", 15);
+    nextFromList("net").transitions.add(self);
+}
+
+@probability 0.7
+pattern Transition
+net:PetriNet,
+tra:Transition
+from: net.transitions {
+    onmatch {
+        var size = 0;
+        var freeSources = Place.all().select(s | s.incoming.size() == size);
+        while (freeSources.isEmpty()) {
+            size += 1;
+            freeSources = Place.all().select(s | s.incoming.size() == size);
+        }
+        size = 0;
+        var freeTarget = Place.all().select(s | s.outgoing.size() == size);
+        while (freeTarget.isEmpty()) {
+            size += 1;
+            freeTarget = Place.all().select(s | s.outgoing.size() == size);
+        }
+        var source = nextFromCollection(freeSources);
+        var target = nextFromCollection(freeTarget);
+        var a1:Arc = new PlaceToTransArc();
+        a1.weight = nextInt(10);
+        a1.source = source;
+        net.places.add(source);
+        a1.target = tra;
+        net.arcs.add(a1);
+        var a2:Arc = new TransToPlaceArc();
+        a1.weight = nextInt(10);
+        a2.source = tra;
+        a2.target = target;
+        net.places.add(target);
+        net.arcs.add(a2);
+    }
+}

--- a/mkdocs/docs/playground/templates/java/emg/src/main/java/org/eclipse/epsilon/examples/Example.java
+++ b/mkdocs/docs/playground/templates/java/emg/src/main/java/org/eclipse/epsilon/examples/Example.java
@@ -1,0 +1,42 @@
+package org.eclipse.epsilon.examples;
+
+import java.io.File;
+
+import org.eclipse.emf.ecore.resource.Resource;
+import org.eclipse.emf.emfatic.core.EmfaticResourceFactory;
+import org.eclipse.epsilon.emc.emf.EmfModel;
+import org.eclipse.epsilon.emg.EmgModule;
+import org.eclipse.epsilon.flexmi.FlexmiResourceFactory;
+
+public class Example {
+
+    public static void main(String[] args) throws Exception {
+
+        // Register the Flexmi and Emfatic parsers with EMF
+        Resource.Factory.Registry.INSTANCE.getExtensionToFactoryMap().put("flexmi", new FlexmiResourceFactory());
+        Resource.Factory.Registry.INSTANCE.getExtensionToFactoryMap().put("emf", new EmfaticResourceFactory());
+
+        // Parse the EMG program
+        EmgModule module = new EmgModule();
+        module.parse(new File("program.emg"));
+
+        // Create a model in model.xmi using metamodel.emf as its metamodel
+        EmfModel model = new EmfModel();
+        model.setName("Model");
+        // We use XMI instead of Flexmi as the format of the target model as Flexmi is a read-only format
+        model.setModelFile("model.xmi");
+        model.setMetamodelFile("metamodel.emf");
+        model.setReadOnLoad(false);
+        model.setStoredOnDisposal(true);
+        model.load();
+
+        // Make the models available to the generation
+        module.getContext().getModelRepository().addModel(model);
+
+        // Execute the EMG program
+        module.execute();
+
+        // Save the target model and dispose of both models
+        module.getContext().getModelRepository().dispose();
+    }
+}

--- a/mkdocs/docs/playground/templates/maven/pom.xml.handlebars
+++ b/mkdocs/docs/playground/templates/maven/pom.xml.handlebars
@@ -38,7 +38,7 @@
                     <dependency>
                         <groupId>org.eclipse.epsilon</groupId>
                         <artifactId>org.eclipse.epsilon.workflow</artifactId>
-                        <version>2.5.0-SNAPSHOT</version>
+                        <version>2.5.0</version>
                     </dependency>
                     <dependency>
                         <groupId>org.eclipse.epsilon</groupId>

--- a/mkdocs/docs/playground/templates/maven/pom.xml.handlebars
+++ b/mkdocs/docs/playground/templates/maven/pom.xml.handlebars
@@ -38,7 +38,7 @@
                     <dependency>
                         <groupId>org.eclipse.epsilon</groupId>
                         <artifactId>org.eclipse.epsilon.workflow</artifactId>
-                        <version>2.4.0</version>
+                        <version>2.5.0-SNAPSHOT</version>
                     </dependency>
                     <dependency>
                         <groupId>org.eclipse.epsilon</groupId>


### PR DESCRIPTION
This PR adds support for EMG in the front-end side of the playground. Check [this other PR](https://github.com/epsilonlabs/playground/pull/2) for the back-end counterpart. 

In particular this adds:
- [x] A 'Model Generation Examples' folder, under which a Petri Net Generation example is added.
- [x] Appropriate panel management for EMG, showing console, ~model,~ metamodel, and resulting generated model graphically.
- [x] Syntax highlighting for EMG.
- [x] An increment of the test suit for the example.
- [x] Templates for Gradle, Maven, Ant (Eclipse), Java (Gradle), and Java (Maven).

What lacks is:
- [ ] A proper EMG *.gif icon. I have used the EPL one in the meantime (in /mkdocs/docs/playground/css/custom.css).
- [ ] Re-bundling the new code -- I still get metro4 problems with webpack on my machine.
- [x] ~I think the Download dialog produces syntactically correct Gradle / Maven / ... artifacts, but `<epsilon.emg>` is either not defined or exposed correctly in `org.eclipse.epsilon.workflow:2.4.0`.~

Preview:
![Result](https://github.com/eclipse/epsilon-website/assets/93224318/72e1ce64-8543-4bce-97af-ac95bdc4110c)
